### PR TITLE
[Bugfix] Eliminate Warning - Change flet To cl-flet

### DIFF
--- a/change-inner.el
+++ b/change-inner.el
@@ -82,7 +82,7 @@ kills the innards of the first ancestor semantic unit starting with that char."
                      "Change inner, starting with:"
                    "Yank inner, starting with:"))))
          (q-char (regexp-quote char)))
-    (flet ((message (&rest args) nil))
+    (cl-flet ((message (&rest args) nil))
       (save-excursion
         (er/expand-region 1)
         (er/expand-region 1)
@@ -114,7 +114,7 @@ kills the first ancestor semantic unit starting with that char."
                      "Change outer, starting with:"
                    "Yank outer, starting with:"))))
          (q-char (regexp-quote char)))
-    (flet ((message (&rest args) nil))
+    (cl-flet ((message (&rest args) nil))
       (save-excursion
         (when (looking-at q-char)
           (er/expand-region 1))


### PR DESCRIPTION
* Emacs 24.4+ issues a deprecation warning in regards to flet indicate
  cl-flet or cl-letf as the future alternatives. Replace all occurences
  with cl-flet to eliminate the warning.